### PR TITLE
feat: Add play functionality to Lesson and Module components

### DIFF
--- a/src/components/Lesson.tsx
+++ b/src/components/Lesson.tsx
@@ -3,11 +3,15 @@ import { Video } from "lucide-react";
 interface ILessonProps {
   title: string;
   duration: string;
+  onPlay: () => void;
 }
 
-export function Lesson({ title, duration }: ILessonProps) {
+export function Lesson({ title, duration, onPlay }: ILessonProps) {
   return (
-    <button className="flex items-center gap-3 text-sm text-zinc-400">
+    <button
+      className="flex items-center gap-3 text-sm text-zinc-400"
+      onClick={onPlay}
+    >
       <Video className="w-4 h-4 text-zinc-500" />
       <span>{title}</span>
       <span className="ml-auto font-mono text-xs text-zinc-500">

--- a/src/components/Module.tsx
+++ b/src/components/Module.tsx
@@ -2,6 +2,8 @@ import { ChevronDown } from "lucide-react";
 import { Lesson } from "./Lesson";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { useAppSelector } from "../store";
+import { useDispatch } from "react-redux";
+import { play } from "../store/slices/player";
 
 interface IModuleProps {
   moduleIndex: number;
@@ -10,9 +12,21 @@ interface IModuleProps {
 }
 
 export function Module({ moduleIndex, title, lessonsCount }: IModuleProps) {
+  const dispatch = useDispatch();
+
   const lessons = useAppSelector((state) => {
     return state.player.course.modules[moduleIndex].lessons;
   });
+
+  const handleOnPlay = (moduleIndex: number, lessonIndex: number) => {
+    dispatch(
+      play({
+        moduleIndex,
+        lessonIndex,
+      }),
+    );
+  };
+
   return (
     <div>
       <Collapsible.Root className="group">
@@ -33,11 +47,12 @@ export function Module({ moduleIndex, title, lessonsCount }: IModuleProps) {
 
         <Collapsible.Content>
           <nav className="relative flex flex-col gap-4 p-6">
-            {lessons.map((lesson) => (
+            {lessons.map((lesson, lessonIndex) => (
               <Lesson
                 key={lesson.id}
                 title={lesson.title}
                 duration={lesson.duration}
+                onPlay={() => handleOnPlay(moduleIndex, lessonIndex)}
               />
             ))}
           </nav>

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -1,13 +1,22 @@
 import ReactPlayer from "react-player";
+import { useAppSelector } from "../store";
 
 export function Video() {
+  const lesson = useAppSelector((state) => {
+    const { currentModuleIndex, currentLessonIndex } = state.player;
+    const currentLesson =
+      state.player.course.modules[currentModuleIndex].lessons[
+        currentLessonIndex
+      ];
+    return currentLesson;
+  });
   return (
     <div className="w-full bg-zinc-950 aspect-video">
       <ReactPlayer
         width="100%"
         height="100%"
         controls
-        url="https://www.youtube.com/watch?v=sl4GO6pgRas&list=RDbX_U76aINZE&index=5"
+        url={`https://www.youtube.com/watch?v=${lesson.id}`}
       />
     </div>
   );

--- a/src/store/slices/player.ts
+++ b/src/store/slices/player.ts
@@ -64,8 +64,15 @@ const playerSlice = createSlice({
         },
       ],
     },
+    currentModuleIndex: 0,
+    currentLessonIndex: 0,
   },
-  reducers: {},
+  reducers: {
+    play: (state, action) => {
+      state.currentModuleIndex = action.payload.moduleIndex;
+      state.currentLessonIndex = action.payload.lessonIndex;
+    },
+  },
 });
 
 /**
@@ -73,3 +80,5 @@ const playerSlice = createSlice({
  * del store, en este caso el estado del slice y una acción.
  */
 export const player = playerSlice.reducer;
+
+export const { play } = playerSlice.actions;


### PR DESCRIPTION
- Added `onPlay` prop to Lesson component
- Updated Lesson component to include an `onClick` event handler for the play button
- Dispatched a `play` action with the module and lesson indices in the handleOnPlay function in Module component
- Updated Video component to dynamically set the video URL based on the current lesson's ID from the store