### PR TITLE
feat: show current lesson and module in header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,22 @@
+import { useAppSelector } from "../store";
+
 export function Header() {
+  const { moduleTitle, lessonTitle } = useAppSelector((state) => {
+    const { currentModuleIndex, currentLessonIndex } = state.player;
+
+    const currentModule = state.player.course.modules[currentModuleIndex];
+    const currentLesson = currentModule.lessons[currentLessonIndex];
+
+    return {
+      moduleTitle: currentModule.title,
+      lessonTitle: currentLesson.title,
+    };
+  });
+
   return (
     <div className="flex flex-col gap-1">
-      <h1 className="text-2xl font-bold">Fundamentos do Redux</h1>
-      <span className="text-sm text-zinc-400">
-        Módulo "Desvendando o Redux"
-      </span>
+      <h1 className="text-2xl font-bold">{lessonTitle}</h1>
+      <span className="text-sm text-zinc-400">{moduleTitle}</span>
     </div>
   );
 }

--- a/src/components/Lesson.tsx
+++ b/src/components/Lesson.tsx
@@ -1,18 +1,30 @@
-import { Video } from "lucide-react";
+import { PlayCircle, Video } from "lucide-react";
 
 interface ILessonProps {
   title: string;
   duration: string;
   onPlay: () => void;
+  isCurrent?: boolean;
 }
 
-export function Lesson({ title, duration, onPlay }: ILessonProps) {
+export function Lesson({
+  title,
+  duration,
+  onPlay,
+  isCurrent = false,
+}: ILessonProps) {
   return (
     <button
-      className="flex items-center gap-3 text-sm text-zinc-400"
+      data-active={isCurrent}
       onClick={onPlay}
+      disabled={isCurrent}
+      className="flex items-center gap-3 text-sm data-[active=true]:text-emerald-400 text-zinc-400 enabled:hover:text-zinc-100"
     >
-      <Video className="w-4 h-4 text-zinc-500" />
+      {isCurrent ? (
+        <PlayCircle className="w-4 h-4 text-emerald-400" />
+      ) : (
+        <Video className="w-4 h-4 text-zinc-500" />
+      )}
       <span>{title}</span>
       <span className="ml-auto font-mono text-xs text-zinc-500">
         {duration}

--- a/src/components/Module.tsx
+++ b/src/components/Module.tsx
@@ -14,8 +14,14 @@ interface IModuleProps {
 export function Module({ moduleIndex, title, lessonsCount }: IModuleProps) {
   const dispatch = useDispatch();
 
-  const lessons = useAppSelector((state) => {
-    return state.player.course.modules[moduleIndex].lessons;
+  const data = useAppSelector((state) => {
+    const lessons = state.player.course.modules[moduleIndex].lessons;
+    const { currentModuleIndex, currentLessonIndex } = state.player;
+    return {
+      lessons,
+      currentModuleIndex,
+      currentLessonIndex,
+    };
   });
 
   const handleOnPlay = (moduleIndex: number, lessonIndex: number) => {
@@ -47,14 +53,21 @@ export function Module({ moduleIndex, title, lessonsCount }: IModuleProps) {
 
         <Collapsible.Content>
           <nav className="relative flex flex-col gap-4 p-6">
-            {lessons.map((lesson, lessonIndex) => (
-              <Lesson
-                key={lesson.id}
-                title={lesson.title}
-                duration={lesson.duration}
-                onPlay={() => handleOnPlay(moduleIndex, lessonIndex)}
-              />
-            ))}
+            {data.lessons.map((lesson, lessonIndex) => {
+              const isCurrent =
+                data.currentModuleIndex === moduleIndex &&
+                data.currentLessonIndex === lessonIndex;
+
+              return (
+                <Lesson
+                  key={lesson.id}
+                  title={lesson.title}
+                  duration={lesson.duration}
+                  onPlay={() => handleOnPlay(moduleIndex, lessonIndex)}
+                  isCurrent={isCurrent}
+                />
+              );
+            })}
           </nav>
         </Collapsible.Content>
       </Collapsible.Root>


### PR DESCRIPTION
This pull request introduces several updates to the application's UI components to dynamically display course content based on the current state:

1. Header.tsx: Now uses useAppSelector to fetch the current module and lesson titles from the Redux state and displays them, replacing the static text that was there before.

2. Lesson.tsx: Adds an isCurrent prop to indicate the currently playing lesson. It conditionally renders a PlayCircle icon for the active lesson and disables the button to prevent replaying the current lesson.

3. Module.tsx: Enhances the component to determine if a lesson is the current one being played and passes this information to the Lesson component.

https://github.com/JuanAntonSP/rs-redux-zustand/assets/1317580/14b42cc2-1e58-47e2-9980-80eb3b505df4

